### PR TITLE
Workaround for repos with dots in their names. Fixes #1

### DIFF
--- a/public/javascripts/views/user.js
+++ b/public/javascripts/views/user.js
@@ -72,7 +72,11 @@ var UserView = function(){
       $(selectors.loading).html("Loading downloads (0/" + data.length + ")...");
       for(var i = 0; i < data.length; i++){
         var fetched = 0,
-            divId = username + "-" + data[i];
+            divId = username + "-" + data[i].replace(/\./g, "-");
+            
+        while ($("#" + divId).length) {
+          divId += "-";
+        }
 
         $(selectors.repositories).append(templates.repositoryDiv(divId, data[i]));
 


### PR DESCRIPTION
This should solve the dot issue. Renaming the div is a bit of a hack, but it's easier than making sure everything else (including third-party plugins) remembers to escape dots in the id when creating a query from an element id.

I've added a loop to make sure the new divId is unique (which is neccessary because a user could reasonably have the same repo on his account twice, once with a dash and once with a dot).
